### PR TITLE
[hexbw] [nixdeploy] Cluster deploy with nix description

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -7,4 +7,4 @@ import Prelude hiding (FilePath)
 import Shelly hiding (command)
 
 main :: IO ()
-main = makeDeploymentCLI deployOptionsParser id defaultNixPlan
+main = makeDeploymentCLI deployOptionsParser id $ const $ defaultNixPlan False

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -7,4 +7,4 @@ import Prelude hiding (FilePath)
 import Shelly hiding (command)
 
 main :: IO ()
-main = makeDeploymentCLI deployOptionsParser id $ const $ defaultNixPlan False
+main = makeDeploymentCLI deployOptionsParser id $ defaultNixPlan False

--- a/data/get-derivs.nix
+++ b/data/get-derivs.nix
@@ -1,0 +1,22 @@
+# Extracts derivations list from deployment description
+{
+  machines,
+  ...
+}:
+let
+  pkgs = import <nixpkgs> {};
+  lib = pkgs.lib;
+
+  fromService = {
+    unit
+  , ...
+  }: unit;
+
+  fromMachine = {
+      derivations ? []
+    , services ? {}
+    , ...
+    }: derivations ++ lib.mapAttrsToList (name: fromService) services;
+
+  perMachine = lib.mapAttrsToList (name: fromMachine) machines;
+in lib.unique (lib.flatten perMachine)

--- a/examples/multiple/README.md
+++ b/examples/multiple/README.md
@@ -1,0 +1,4 @@
+# Example for multiple machine setup
+
+Demo of how to write `nixdeploy` configuration that deploy several machines. The example deploys
+[iperf3](https://en.wikipedia.org/wiki/Iperf) servers to measure network connection bandwidth.

--- a/examples/multiple/deploy.nix
+++ b/examples/multiple/deploy.nix
@@ -35,7 +35,6 @@ let
         enable = true; # auto-start?
       };
     };
-    derivations = [pkgs.dante];
     backend = "Ubuntu"; # Which internal backend to use
   };
 in {

--- a/examples/multiple/deploy.nix
+++ b/examples/multiple/deploy.nix
@@ -1,0 +1,48 @@
+{
+  machine1 # ip of first machine
+#, machine2 # ip of second machine
+#, machine3 # ip of third machine
+, sshPort ? 22
+, sshUser ? "root"
+}:
+let
+  pkgs = import ../pkgs.nix { };
+  # Function that creates description of single iperf server
+  makeIPerfMachine = host: {
+    host = host; # Host of machine to connect to via SSH
+    port = sshPort; # Port of machine to connect to via SSH
+    user = sshUser; # User of machine with passwordless sudo and allowed SSH login
+    services = { # Set of systemd services to install and start
+      iperf = { # key value is used as name of systemd unit file
+        unit = pkgs.writeTextFile { # text of the systemd unit
+          name = "iperf-unit";
+          text = ''
+            [Unit]
+            Description=Iperf3 bandwidth measurement server
+            After=networking.target
+
+            [Service]
+            Restart=on-failure
+            RestartSec=15
+            ExecStart=${pkgs.iperf3}/bin/iperf -s --port 5001
+            User=root
+            KillMode=process
+
+            [Install]
+            WantedBy=multi-user.target
+            '';
+          };
+        enable = true; # auto-start?
+      };
+    };
+    derivations = [pkgs.dante];
+    backend = "Ubuntu"; # Which internal backend to use
+  };
+in {
+  # Description of each remote machine
+  machines = {
+    iperf1 = makeIPerfMachine machine1;
+    iperf2 = makeIPerfMachine machine1;
+#    iperf3 = makeIPerfMachine machine3;
+  };
+}

--- a/examples/multiple/deploy.nix
+++ b/examples/multiple/deploy.nix
@@ -1,7 +1,7 @@
 {
   machine1 # ip of first machine
-#, machine2 # ip of second machine
-#, machine3 # ip of third machine
+, machine2 # ip of second machine
+, machine3 # ip of third machine
 , sshPort ? 22
 , sshUser ? "root"
 }:
@@ -42,7 +42,7 @@ in {
   # Description of each remote machine
   machines = {
     iperf1 = makeIPerfMachine machine1;
-    iperf2 = makeIPerfMachine machine1;
-#    iperf3 = makeIPerfMachine machine3;
+    iperf2 = makeIPerfMachine machine2;
+    iperf3 = makeIPerfMachine machine3;
   };
 }

--- a/examples/multiple/deploy_aws_example.sh
+++ b/examples/multiple/deploy_aws_example.sh
@@ -1,0 +1,2 @@
+# Uses ubuntu 16.04 LTS
+nix-shell ../../default.nix --command "nixdeploy deploy --argstr \"machine1:$1\" --argstr \"sshUser:ubuntu\" ./deploy.nix"

--- a/examples/multiple/deploy_aws_example.sh
+++ b/examples/multiple/deploy_aws_example.sh
@@ -1,2 +1,2 @@
 # Uses ubuntu 16.04 LTS
-nix-shell ../../default.nix --command "nixdeploy deploy --argstr \"machine1:$1\" --argstr \"machine2:$2\" --argstr \"machine2:$3\" --argstr \"sshUser:ubuntu\""
+nix-shell ../../shell.nix --command "nixdeploy deploy --argstr \"machine1:$1\" --argstr \"machine2:$2\" --argstr \"machine3:$3\" --argstr \"sshUser:ubuntu\""

--- a/examples/multiple/deploy_aws_example.sh
+++ b/examples/multiple/deploy_aws_example.sh
@@ -1,2 +1,2 @@
 # Uses ubuntu 16.04 LTS
-nix-shell ../../default.nix --command "nixdeploy deploy --argstr \"machine1:$1\" --argstr \"sshUser:ubuntu\" ./deploy.nix"
+nix-shell ../../default.nix --command "nixdeploy deploy --argstr \"machine1:$1\" --argstr \"machine2:$2\" --argstr \"machine2:$3\" --argstr \"sshUser:ubuntu\""

--- a/examples/pkgs.nix
+++ b/examples/pkgs.nix
@@ -1,0 +1,6 @@
+import ((import <nixpkgs> {}).fetchFromGitHub {
+  owner = "NixOS";
+  repo = "nixpkgs-channels";
+  rev = "aebdc892d6aa6834a083fb8b56c43578712b0dab";
+  sha256  = "1bcpjc7f1ff5k7vf5rwwb7g7m4j238hi4ssnx7xqglr7hj4ms0cz";
+})

--- a/examples/pkgs.nix
+++ b/examples/pkgs.nix
@@ -1,6 +1,6 @@
 import ((import <nixpkgs> {}).fetchFromGitHub {
   owner = "NixOS";
   repo = "nixpkgs-channels";
-  rev = "aebdc892d6aa6834a083fb8b56c43578712b0dab";
-  sha256  = "1bcpjc7f1ff5k7vf5rwwb7g7m4j238hi4ssnx7xqglr7hj4ms0cz";
+  rev = "3fe7cddc304abb86e61a750a4f807270c7ca7825";
+  sha256  = "13z9whcylsr76z3npc8v8hxalli6jz9h3jv5z4b97cli1kp9y04k";
 })

--- a/examples/single/README.md
+++ b/examples/single/README.md
@@ -1,0 +1,4 @@
+# Example for single machine deployment
+
+Demo of how to write basic `nixdeploy` configuration. The example deploys
+[dante](https://www.inet.no/dante/) SOCKS proxy. 

--- a/examples/single/deploy.nix
+++ b/examples/single/deploy.nix
@@ -1,6 +1,6 @@
 {
   testMachineHost ? "127.0.0.1"
-, testMachinePort ? "22"
+, testMachinePort ? 22
 , testMachineUser ? "root"
 }:
 let

--- a/examples/single/deploy.nix
+++ b/examples/single/deploy.nix
@@ -1,0 +1,77 @@
+{
+  testMachineHost ? "127.0.0.1"
+, testMachinePort ? "22"
+, testMachineUser ? "root"
+}:
+let
+  pkgs = import ../pkgs.nix { };
+  dante-config = pkgs.writeTextFile {
+    name = "danted.conf";
+    text = ''
+      logoutput: syslog /var/log/dante/danted.log
+      internal: eth0 port = 1080
+      external: eth0
+
+      socksmethod: username
+      user.privileged: root
+      user.unprivileged: nobody
+
+      client pass {
+          from: 0.0.0.0/0 to: 0.0.0.0/0
+          log: error
+      }
+
+      socks pass {
+          from: 0.0.0.0/0 to: 0.0.0.0/0
+          command: connect
+          log: error
+          socksmethod: username
+      }
+      '';
+    };
+  dante-unit = pkgs.writeTextFile {
+    name = "dante-unit";
+    text = ''
+      [Unit]
+      Description=Dante socks proxy server
+      After=networking.target
+      ConditionPathExists=!/var/run/sockd.pid
+
+      [Service]
+      Restart=on-failure
+      RestartSec=15
+      ExecStart=${pkgs.dante}/bin/sockd -f ${dante-config} -N 1
+      User=root
+      ExecReload=/bin/kill -HUP $MAINPID
+      PIDFile=/var/run/sockd.pid
+      KillMode=process
+
+      [Install]
+      WantedBy=multi-user.target
+      '';
+    };
+in {
+  # General deployment options
+  deployment.user = "deploy"; # Which user will own /nix and profile
+  # Description of each remote machine 
+  machines = {
+    testMachine = { # Single machine to deploy
+      host = testMachineHost; # Host of machine to connect to via SSH
+      port = testMachinePort; # Port of machine to connect to via SSH
+      user = testMachineUser; # User of machine with passwordless sudo and allowed SSH login
+      services = { # Set of systemd services to install and start
+        dante = { # key value is used as name of systemd unit file
+          unit = dante-unit; # text of the systemd unit
+          enable = true; # auto-start?
+        };
+      };
+      folders = [ { # Folders to create, doesn't touch existing folders
+          path = "/var/log/dante";
+          owner = "root"; # default is deployment user
+        }
+        ];
+      derivations = [pkgs.dante]; # Additional derivations to copy to deployment profile
+      backend = "Ubuntu"; # Which internal backend to use
+    };
+  };
+}

--- a/examples/single/deploy.nix
+++ b/examples/single/deploy.nix
@@ -53,7 +53,7 @@ let
 in {
   # General deployment options
   deployment.user = "deploy"; # Which user will own /nix and profile
-  # Description of each remote machine 
+  # Description of each remote machine
   machines = {
     testMachine = { # Single machine to deploy
       host = testMachineHost; # Host of machine to connect to via SSH
@@ -65,7 +65,7 @@ in {
           enable = true; # auto-start?
         };
       };
-      folders = [ { # Folders to create, doesn't touch existing folders
+      directories = [ { # Folders to create, doesn't touch existing folders
           path = "/var/log/dante";
           owner = "root"; # default is deployment user
         }

--- a/examples/single/deploy_aws_example.sh
+++ b/examples/single/deploy_aws_example.sh
@@ -1,0 +1,2 @@
+# Uses ubuntu 16.04 LTS
+nix-shell ../../default.nix --command "nixdeploy deploy --argstr \"testMachineHost:$1\" --argstr \"testMachineUser:ubuntu\" ./deploy.nix"

--- a/examples/single/deploy_aws_example.sh
+++ b/examples/single/deploy_aws_example.sh
@@ -1,2 +1,3 @@
 # Uses ubuntu 16.04 LTS
-nix-shell ../../default.nix --command "nixdeploy deploy --argstr \"testMachineHost:$1\" --argstr \"testMachineUser:ubuntu\" ./deploy.nix --verbose"
+set -x
+nix-shell ../../shell.nix --command "nixdeploy deploy --argstr \"testMachineHost:$1\" --argstr \"testMachineUser:ubuntu\" ./deploy.nix --verbose"

--- a/examples/single/deploy_aws_example.sh
+++ b/examples/single/deploy_aws_example.sh
@@ -1,2 +1,2 @@
 # Uses ubuntu 16.04 LTS
-nix-shell ../../default.nix --command "nixdeploy deploy --argstr \"testMachineHost:$1\" --argstr \"testMachineUser:ubuntu\" ./deploy.nix"
+nix-shell ../../default.nix --command "nixdeploy deploy --argstr \"testMachineHost:$1\" --argstr \"testMachineUser:ubuntu\" ./deploy.nix --verbose"

--- a/nixdeploy.cabal
+++ b/nixdeploy.cabal
@@ -26,6 +26,7 @@ library
       base                  >= 4.7      && < 5
     , aeson                 >= 0.11     && < 1.3
     , ansi-terminal         >= 0.6      && < 0.7
+    , bytestring            >= 0.10     && < 0.11
     , containers            >= 0.5      && < 0.6
     , directory             >= 1.3      && < 1.4
     , exceptions            >= 0.8      && < 0.9

--- a/nixdeploy.cabal
+++ b/nixdeploy.cabal
@@ -17,13 +17,19 @@ library
   hs-source-dirs: src
   exposed-modules:
     Deployment.Nix
+    Deployment.Nix.Aeson
+    Deployment.Nix.Config
     Deployment.Nix.Task
     Deployment.Nix.Task.Common
   default-language: Haskell2010
   build-depends:
       base                  >= 4.7      && < 5
+    , aeson                 >= 0.11     && < 1.3
     , ansi-terminal         >= 0.6      && < 0.7
+    , containers            >= 0.5      && < 0.6
+    , directory             >= 1.3      && < 1.4
     , exceptions            >= 0.8      && < 0.9
+    , filepath              >= 1.4      && < 1.5
     , filepath              >= 1.4      && < 1.5
     , optparse-applicative  >= 0.13     && < 0.14
     , safe                  >= 0.3      && < 0.4
@@ -32,8 +38,12 @@ library
     , text                  >= 1.2      && < 1.3
     , transient             >= 0.5      && < 0.6
     , transient-universe    >= 0.4      && < 0.5
+    , uniplate              >= 1.6      && < 1.7
   default-extensions:
+    DeriveDataTypeable
+    DeriveGeneric
     GADTs
+    GeneralizedNewtypeDeriving
     OverloadedStrings
     RecordWildCards
     ScopedTypeVariables

--- a/nixdeploy.cabal
+++ b/nixdeploy.cabal
@@ -30,6 +30,7 @@ library
     , containers            >= 0.5      && < 0.6
     , directory             >= 1.3      && < 1.4
     , exceptions            >= 0.8      && < 0.9
+    , file-embed            >= 0.0      && < 0.1
     , filepath              >= 1.4      && < 1.5
     , filepath              >= 1.4      && < 1.5
     , optparse-applicative  >= 0.13     && < 0.14

--- a/src/Deployment/Nix.hs
+++ b/src/Deployment/Nix.hs
@@ -6,16 +6,15 @@ module Deployment.Nix(
   , RemoteHost(..)
   , NixBuildInfo(..)
   , runDeployment
-  , getNixBuildInfo
   , getRemoteHost
   , module R
   -- * CLI helpers
   , deployOptionsParser
   , makeDeploymentCLI
   , defaultNixPlan
-  , nixifyPlan
   ) where
 
+import Control.Monad.IO.Class
 import Data.Foldable (traverse_, for_)
 import Data.Functor
 import Data.Maybe
@@ -28,6 +27,7 @@ import Shelly hiding (command)
 import System.FilePath (takeFileName)
 import Transient.Base hiding (option)
 
+import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 
 import Deployment.Nix.Task as R
@@ -36,13 +36,12 @@ import Deployment.Nix.Task.Common as R
 -- | CLI options
 data DeployOptions = DeployOptions {
   deployCommand       :: Command
-, deployNixFile       :: Text -- ^ Path to .nix file with derivations that need to be deployed
-, deployNixArgs       :: [Text] -- ^ Arguments that are passed to nix deployment file
+, deployNixFile       :: Text       -- ^ Path to .nix file with full description of deployment. Config is generated from the nix expression.
+, deployNixArgs       :: [Text]     -- ^ Arguments that are passed to nix deployment file
 , deployNixSshConfig  :: Maybe Text -- ^ Path to ssh-config to use for nix-build
-, deployPostgres      :: Maybe Text -- ^ Path to deriviation with SQL init script
-, deployDry           :: Bool -- ^ Only print wich tasks need to be deployed
-, deployVerbose       :: Bool -- ^ Verbose output from shell
-, deployForce         :: Bool -- ^ When enabled, force all checks to apply tasks
+, deployDry           :: Bool       -- ^ Only print wich tasks need to be deployed
+, deployVerbose       :: Bool       -- ^ Verbose output from shell
+, deployForce         :: Bool       -- ^ When enabled, force all checks to apply tasks
 }
 
 -- | Available CLI commands to perform
@@ -62,27 +61,45 @@ getRemoteHost MachineCfg{..} = RemoteHost {
   , remoteUser = fromMaybe "root" machineUser
   }
 
+-- | Get some value from global deployment config with overriding from local machine config
+getDeploymentSmth :: a -> (DeploymentCfg -> Maybe a) -> Config -> MachineCfg -> a
+getDeploymentSmth defVal getter Config{..} MachineCfg{..} = fromMaybe defVal $ (getter =<< machineDeployment) <|> getter configDeployment
+
+-- | Calculate user-owner of deployment files with overriding from local machine settings
+getDeploymentUser :: Config -> MachineCfg -> UserName
+getDeploymentUser = getDeploymentSmth "deploy" deploymentUser
+
+-- | Calculate user-owner of deployment files with overriding from local machine settings
+getDeploymentKeys :: Config -> MachineCfg -> [KeyPath]
+getDeploymentKeys = getDeploymentSmth ["~/.ssh/id_rsa"] deploymentKeys
+-- home <- fromText . T.filter (/= '\n') <$> bash "echo" ["$HOME"]
+
+-- | Calculate user-owner of deployment files with overriding from local machine settings
+getDeploymentKeysTimeout :: Config -> MachineCfg -> Int
+getDeploymentKeysTimeout = getDeploymentSmth 300 deploymentKeysTimeout
+
 -- | Transform nix file to desired config
 loadConfig :: MonadIO m => DeployOptions -> m Config
 loadConfig DeployOptions{..} = undefined
 
 -- | Execute program with given options
-runDeployment :: DeployOptions -> Task () -> IO ()
+runDeployment :: DeployOptions -> (Config -> Task ()) -> IO ()
 runDeployment o@DeployOptions{..} buildPlan = do
-  Config{..} <- loadConfig o
+  cfg@Config{..} <- loadConfig o
   let dryRun ma = do
-
         infos <- dryRunTask ma
         liftIO $ traverse_ (\(mn, b) -> echonColor White (fromMaybe "unnamed" mn <> " is ") >> if b then echoColor Green "applied" else echoColor Red "not applied" ) infos
   void $ keep' $ do
     setShellOptions ShellOptions {
         shellVerbose = deployVerbose
       }
+    let bldPlan = buildPlan cfg
     case deployCommand of
       CommandDeploy ->
-        if deployDry then dryRun buildPlan else void $ executeTask deployForce buildPlan
-      CommandRevert -> if deployDry then dryRun buildPlan else reverseTask buildPlan
-      CommandNixify -> if deployDry then dryRun (nixifyPlan o) else executeTask deployForce $ nixifyPlan o
+        if deployDry then dryRun bldPlan else void $ executeTask deployForce bldPlan
+      CommandRevert -> if deployDry then dryRun bldPlan else reverseTask bldPlan
+      CommandNixify -> let plan = defaultNixPlan True cfg in if deployDry
+        then dryRun plan else executeTask deployForce plan
 
 -- | Helper to parse text
 textArgument :: Mod ArgumentFields String -> Parser Text
@@ -97,62 +114,20 @@ deployOptionsParser :: Parser DeployOptions
 deployOptionsParser = DeployOptions
   <$> cliCommand
   <*> textArgument (
-      metavar "MACHINE_IP"
-    )
-  <*> textArgument (
        metavar "NIX_FILE"
     <> showDefault
-    <> value "./default.nix"
-    <> help "Which .nix file to deploy"
+    <> value "./deploy.nix"
+    <> help "Path to .nix file with full description of deployment."
+    )
+  <*> (many . textOption) (
+       long "arg"
+    <> metavar "Nix file argument in format 'key:value'"
+    <> help "Multiple arguments can be specified. The arguments are passed to NIX_FILE via nix-instantiate --arg option."
     )
   <*> (optional . textOption) (
        long "nix-ssh-config"
     <> metavar "NIX_SSH_CONFIG"
-    <> help "Which ssh config to use with nix-build"
-    )
-  <*> (many . textOption) (
-       long "key"
-    <> metavar "SSH_PRIVATE_KEY_PATH"
-    <> help "Path to encrypted private key that will be added to ssh-agent"
-    )
-  <*> (optional . option auto) (
-       long "keys-timeout"
-    <> metavar "INT_SECONDS"
-    <> help "Number of seconds the ssh keys will expired after"
-    )
-  <*> option auto (
-       long "port"
-    <> short 'p'
-    <> metavar "DEPLOY_PORT"
-    <> showDefault
-    <> value 22
-    <> help "Default SSH port"
-  )
-  <*> (optional . textOption) (
-       long "user"
-    <> short 'u'
-    <> metavar "DEPLOY_USER"
-    <> help "Which user to deploy with (default is root or admin for Debian)"
-    )
-  <*> (many . textOption) (
-       long "service"
-    <> metavar "SERVICE_ATR_NAME"
-    <> help "Derivation in .nix file that should be symlinked as systemd service"
-    )
-  <*> (many . textOption) (
-       long "tool"
-    <> metavar "SERVICE_ATR_NAME"
-    <> help "Derivation in .nix file that should be symlinked as systemd service, but not enabled"
-    )
-  <*> (many . textOption) (
-       long "folder"
-    <> metavar "FOLDER_PATH"
-    <> help "Folder on remote machine that we need to create if it is missing"
-    )
-  <*> (optional . textOption) (
-       long "postgres"
-    <> metavar "SQL_DERIVATION"
-    <> help "If specified, install postgres and feed the given derivation from .nix file as init SQL script"
+    <> help "Which ssh config to use with NIX_FILE"
     )
   <*> switch (
        long "dry"
@@ -169,11 +144,6 @@ deployOptionsParser = DeployOptions
     <> short 'f'
     <> help "Force all checks to 'need to apply'"
     )
-  <*> option auto (
-       long "backend"
-    <> short 'b'
-    <> help "Which command set to use, possible values: Ubuntu, Debian."
-    )
   where
     cliCommand = subparser $
          command "deploy" (info (deployCmd <**> helper) $ progDesc "Apply deployment to remote host")
@@ -186,7 +156,7 @@ deployOptionsParser = DeployOptions
 -- | Generate CLI application for deployment with given build plan
 makeDeploymentCLI :: Parser a -- ^ CLI parser
   -> (a -> DeployOptions) -- ^ How to extract deploy options from the cli parser result
-  -> (a -> Task ()) -- ^ Build plan
+  -> (a -> Config -> Task ()) -- ^ Build plan
   -> IO ()
 makeDeploymentCLI parser getOpts buildPlan = do
   a <- execParser parserInfo
@@ -206,34 +176,21 @@ whenJust :: Applicative f => Maybe a -> (a -> f ()) -> f ()
 whenJust Nothing _ = pure ()
 whenJust (Just a) f = f a
 
--- | Build plan that infest remote host with nix and no more
-nixifyPlan :: DeployOptions -> Task ()
-nixifyPlan opts@DeployOptions{..} = do
-  let
-    rh = getRemoteHost opts
-    deployUser = "deploy"
-  withSshKeys deployKeysTimeout deployKeys $ nixify rh deployUser
-
 -- | Plan to build nix project and deploy it on remote host
-defaultNixPlan :: DeployOptions -> Task ()
-defaultNixPlan opts@DeployOptions{..} = do
+defaultNixPlan :: Bool -> Config -> Task ()
+defaultNixPlan nixifyOnly cfg@Config{..} = for_ configMachines $ \mcfg@MachineCfg{..} -> do
   let
-    nixBuildInfo = getNixBuildInfo opts
-    rh = getRemoteHost opts
-    deployUser = "deploy"
-  withSshKeys deployKeysTimeout deployKeys $ do
+    rh = getRemoteHost mcfg
+    deployUser = getDeploymentUser cfg mcfg
+    keys = getDeploymentKeys cfg mcfg
+    keysTimeout = getDeploymentKeysTimeout cfg mcfg
+  withSshKeys (Just keysTimeout) keys $ do
     nixify rh deployUser
-    derivs <- nixBuild nixBuildInfo
-    liftShell "Print derivs" () $ mapM_ (echo . toTextIgnore) derivs
-    nixCopyClosures rh (headMay deployKeys) deployUser derivs
-    traverse_ (\f -> ensureRemoteFolder rh f "root") deployFolders
-    whenJust deployPostgres $ \derivSqlName -> do
-      derivSql <- nixExtractDeriv nixBuildInfo derivSqlName
-      installPostgres rh derivSql
-    for_ deployTools $ \serviceName -> do
-      service <- nixExtractDeriv nixBuildInfo serviceName
-      nixSymlinkService rh service serviceName False
-    for_ deployServices $ \serviceName -> do
-      service <- nixExtractDeriv nixBuildInfo serviceName
-      nixSymlinkService rh service serviceName True
-      restartRemoteService rh serviceName
+    unless nixifyOnly $ do
+      nixCopyClosures rh (headMay keys) deployUser $ machineAllDerivations mcfg
+      whenJust machineDirectories $ traverse_ (ensureRemoteFolder rh)
+      whenJust machinePostgres $ installPostgres rh
+      whenJust machineServices $ \services -> for_ (M.toList services) $ \(serviceName, ServiceCfg{..}) -> do
+        let enabled = fromMaybe True serviceEnable
+        nixSymlinkService rh serviceUnit serviceName enabled
+        when enabled $ restartRemoteService rh serviceName

--- a/src/Deployment/Nix.hs
+++ b/src/Deployment/Nix.hs
@@ -218,11 +218,12 @@ defaultNixPlan nixifyOnly opts@DeployOptions{..} cfg@Config{..} = do
   derivs <- nixConfigDerivs args (fmap fromText deployNixSshConfig) (fromText deployNixFile)
   nixRelease (fmap fromText deployNixSshConfig) derivs
   let hosts = M.elems $ M.mapWithKey (\name MachineCfg{..} -> (machineHost, name)) configMachines
-  for_ configMachines $ \mcfg@MachineCfg{..} -> do
+  for_ (M.toList configMachines) $ \(name, mcfg@MachineCfg{..}) -> do
     let
       rh = getRemoteHost mcfg
       deployUser = getDeploymentUser cfg mcfg
       keysTimeout = getDeploymentKeysTimeout cfg mcfg
+    setMachineName name
     keys <- liftShell "Get keys local path" [] $ getDeploymentKeys cfg mcfg
     traverse_ (sshAgent $ Just keysTimeout) keys
     nixify rh deployUser

--- a/src/Deployment/Nix/Aeson.hs
+++ b/src/Deployment/Nix/Aeson.hs
@@ -1,0 +1,73 @@
+-- | Overrides aeson TH functions to generate instances
+module Deployment.Nix.Aeson(
+    A.deriveJSON
+  , dropPrefixOptions
+  ) where
+
+import Control.Monad
+import Data.Aeson.TH (Options (..), SumEncoding (..))
+import Data.Aeson.Types (camelTo2, ToJSON(..), FromJSON(..), Value(..))
+import Data.Char (isUpper, toLower, isLower, isPunctuation)
+import Data.List (findIndex)
+import Data.Monoid
+import Data.Text (unpack)
+
+import qualified Data.Aeson.TH as A
+
+-- | Converts first symbol to lower case
+headToLower :: String -> String
+headToLower [] = []
+headToLower (x:xs) = toLower x : xs
+
+-- | Drop prefix of name until first upper letter is occured
+stripFieldPrefix :: String -> String
+stripFieldPrefix = dropWhile (not . isUpper)
+
+-- | Strip prefix of name that exactly matches specified prefix
+stripExactPrefix :: String -- ^ Prefix
+ -> String -- ^ Name
+ -> String -- ^ Name without prefix
+stripExactPrefix = go
+   where
+   go [] name = name
+   go (p : ps) name@(x : xs)
+       | p == x = go ps xs
+       | otherwise = name
+   go _ [] = []
+
+-- | Remove from names things like ' and etc
+dropPunctuation :: String -> String
+dropPunctuation = filter (not . isPunctuation)
+
+-- | Drop upper case prefixes from constructor names
+--
+-- Example:
+-- >>> stripConstructorPrefix "ABCombo"
+-- "Combo"
+--
+-- >>> stripConstructorPrefix "Combo"
+-- "Combo"
+stripConstructorPrefix :: String -> String
+stripConstructorPrefix t =
+   maybe t (flip drop t . decrementSafe) $ findIndex isLower t
+ where
+   decrementSafe 0 = 0
+   decrementSafe i = i - 1
+
+-- | Options for aeson TH generator, that generates following fields:
+--
+-- * without punctuation
+-- * without lowercase prefix
+--
+-- And generates constructor tags without uppercase prefixes with
+-- 'stripConstructorPrefix'.
+--
+-- Sums are encoded as one object with only one field corresponding the
+-- constructor used.
+dropPrefixOptions :: Options
+dropPrefixOptions =
+   A.defaultOptions
+   { fieldLabelModifier = headToLower . stripFieldPrefix . dropPunctuation
+   , constructorTagModifier = stripConstructorPrefix
+   , sumEncoding = ObjectWithSingleField
+   }

--- a/src/Deployment/Nix/Config.hs
+++ b/src/Deployment/Nix/Config.hs
@@ -1,0 +1,127 @@
+-- | Define JSON schema for configuration file that is generated from the nix description
+-- of deployment.
+{-# LANGUAGE TemplateHaskell #-}
+module Deployment.Nix.Config(
+  -- * Helper types
+    MachineName
+  , MachineHost
+  , MachinePort
+  , ServiceName
+  , UserName
+  , KeyPath
+  , AbsolutePath
+  , DerivationPath
+  -- * Config types
+  , Backend(..)
+  , DeploymentCfg(..)
+  , DirectoryCfg(..)
+  , ServiceCfg(..)
+  , MachineCfg(..)
+  , Config(..)
+  -- * Config relative path
+  , ConfigPath(..)
+  , absolutize
+  ) where
+
+import Control.Monad.IO.Class
+import Data.Aeson
+import Data.Aeson.TH
+import Data.Data
+import Data.Generics.Uniplate.Data
+import Data.Map.Strict (Map)
+import Data.String
+import Data.Text (Text)
+import Deployment.Nix.Aeson
+import GHC.Generics
+import System.Directory
+import System.FilePath
+
+-- | Name of deployment target machine
+type MachineName = Text
+
+-- | IP of hostname of target machine
+type MachineHost = Text
+
+-- | Port number of target machine
+type MachinePort = Int
+
+-- | Name of systemd unit
+type ServiceName = Text
+
+-- | Name of system user
+type UserName = Text
+
+-- | Path to SSH key relative to config file location
+type KeyPath = ConfigPath
+
+-- | Absolute path to file or directory
+type AbsolutePath = Text
+
+-- | Full path to NIX derivation in /nix/store
+type DerivationPath = AbsolutePath
+
+-- | Path that is relative to config file location. Transforms via uniplate in
+-- 'absolutize' function.
+newtype ConfigPath = ConfigPath { unConfigPath :: FilePath }
+  deriving (Eq, Ord, Show, Read, Generic, Data, FromJSON, ToJSON)
+
+instance IsString ConfigPath where
+  fromString = ConfigPath
+
+-- | Transform all 'SitePath' to absolute path with given prefix
+absolutize :: (Uniplate a, Data a, MonadIO m) => FilePath -> a -> m a
+absolutize prefix a =  liftIO $ do
+  p <- canonicalizePath prefix
+  transformBiM (mkAbs p) a
+  where
+    mkAbs :: FilePath -> ConfigPath -> IO ConfigPath
+    mkAbs pref (ConfigPath p) = pure . ConfigPath $ if isAbsolute p then p else pref </> p
+
+-- | Enumeration of supported backends
+data Backend = Ubuntu | Debian
+  deriving (Eq, Ord, Show, Read, Generic, Data)
+deriveJSON defaultOptions { unwrapUnaryRecords = True } ''Backend
+
+-- | Generic options that defines deployment options for each machine
+data DeploymentCfg = DeploymentCfg {
+  deploymentUser        :: !(Maybe UserName)  -- ^ Which user will own profile and /nix storage
+, deploymentKeys        :: !(Maybe [KeyPath]) -- ^ Pathes to SSH keys to use for deployment
+, deploymentKeysTimeout :: !(Maybe Int) -- ^ Number of seconds for `deploymentKeys` to expire
+} deriving (Eq, Show, Read, Generic, Data)
+deriveJSON dropPrefixOptions ''DeploymentCfg
+
+-- | Defines directory that should be created (if missing) on remote machine
+data DirectoryCfg = DirectoryCfg {
+  directoryPath     :: !AbsolutePath      -- ^ Path to directory
+, directoryOwner    :: !(Maybe UserName)  -- ^ Name of user that would be owner of the directory
+, directoryReassign :: !(Maybe Bool)      -- ^ Change owner of directory recusively to the `directoryOwner` if directory is created
+, directoryRecreate :: !(Maybe Bool)      -- ^ If set existing folder is erased and new one is created
+} deriving (Eq, Show, Read, Generic, Data)
+deriveJSON dropPrefixOptions ''DirectoryCfg
+
+-- | Defines systemd service config
+data ServiceCfg = ServiceCfg {
+  serviceEnable :: !(Maybe Bool)   -- ^ Is the service enabled? True by default
+, serviceUnit   :: !DerivationPath -- ^ Path to unit file that would be copied
+} deriving (Eq, Show, Read, Generic, Data)
+deriveJSON dropPrefixOptions ''ServiceCfg
+
+-- | Deployment description of a single machine
+data MachineCfg = MachineCfg {
+  machineDeployment  :: !(Maybe DeploymentCfg)                -- ^ Overrides of shared deployment options
+, machineBackend     :: !(Maybe Backend)                      -- ^ Which internal backend to use
+, machineDerivations :: !(Maybe [DerivationPath])             -- ^ Additional derivations to copy
+, machineDirectories :: !(Maybe [DirectoryCfg])               -- ^ Folders to create on remote machine
+, machineHost        :: !MachineHost                          -- ^ Machine network address
+, machinePort        :: !(Maybe MachinePort)                  -- ^ Machine SSH port
+, machineUser        :: !(Maybe UserName)                     -- ^ Machine SSH user that has passwordless sudo
+, machineServices    :: !(Maybe (Map ServiceName ServiceCfg)) -- ^ Systemd services that should be activated
+} deriving (Eq, Show, Read, Generic, Data)
+deriveJSON dropPrefixOptions ''MachineCfg
+
+-- | Config file that is generated from the nix description of deployment.
+data Config = Config {
+  configDeployment :: !DeploymentCfg
+, configMachines   :: !(Map MachineName MachineCfg)
+} deriving (Eq, Show, Read, Generic, Data)
+deriveJSON dropPrefixOptions ''Config

--- a/src/Deployment/Nix/Config.hs
+++ b/src/Deployment/Nix/Config.hs
@@ -131,7 +131,7 @@ machineAllDerivations MachineCfg{..} = fromMaybe [] machineDerivations
 
 -- | Config file that is generated from the nix description of deployment.
 data Config = Config {
-  configDeployment :: !DeploymentCfg
+  configDeployment :: !(Maybe DeploymentCfg)
 , configMachines   :: !(Map MachineName MachineCfg)
 } deriving (Eq, Show, Read, Generic, Data)
 deriveJSON dropPrefixOptions ''Config

--- a/src/Deployment/Nix/Task.hs
+++ b/src/Deployment/Nix/Task.hs
@@ -23,15 +23,12 @@ import Data.Foldable (traverse_)
 import Data.Maybe
 import Data.Monoid
 import Data.Text (Text, pack)
+import Deployment.Nix.Config
 import Shelly
 import System.Console.ANSI
 import Transient.Base
 
 import qualified Data.Text.IO as T
-
--- | Enumeration of supported backends
-data Backend = Ubuntu | Debian
-  deriving (Eq, Ord, Show, Read)
 
 -- | Reversable task on remote machine
 data Task a where

--- a/src/Deployment/Nix/Task/Common.hs
+++ b/src/Deployment/Nix/Task/Common.hs
@@ -70,7 +70,7 @@ dontReverse t = case t of
       taskName = taskName
     , taskCheck = taskCheck
     , taskApply = taskApply
-    , taskReverse = const $ pure ()
+    , taskReverse = pure ()
     }
   TaskApplicative fa ta -> TaskApplicative (dontReverse fa) (dontReverse ta)
   TaskMonadic ta fa -> TaskMonadic (dontReverse ta) (fmap dontReverse fa)
@@ -83,10 +83,10 @@ applyReverse :: a -- ^ Value that will be returned after reverse script
 applyReverse defVal t = case t of
   AtomTask{..} -> AtomTask {
       taskName = ("Reversed " <>) <$> taskName
-    , taskCheck = \backend -> do
-        (_, a) <- taskCheck backend
+    , taskCheck = do
+        (_, a) <- taskCheck
         pure (True, a)
-    , taskApply = \backend -> taskReverse backend >> pure defVal
+    , taskApply = taskReverse >> pure defVal
     , taskReverse = taskReverse
     }
   TaskApplicative fa ta -> TaskApplicative (dontReverse fa) (dontReverse ta)
@@ -108,21 +108,21 @@ bracketReverse ta tb = do
 sshAgent :: Maybe Int -> Maybe FilePath -> Task ()
 sshAgent mseconds mkey = AtomTask {
   taskName = Just $ "Adding key " <> maybe "id_rsa" toTextArg mkey <> " to ssh-agent"
-, taskCheck = const $ transShell $ errExit False $ do
+, taskCheck = transShell $ errExit False $ do
     home <- fromText . T.filter (/= '\n') <$> bash "echo" ["$HOME"]
     hasAgent <- isSshAgentExist
     pubkeys <- T.lines <$> bash "ssh-add" ["-L"]
     pubkey <- readfile $ maybe (home <> ".ssh/id_rsa.pub") (flip addExtensions ["pub"]) mkey
     let isKeyLoaded = pubkey `elem` pubkeys
     pure (not hasAgent || not isKeyLoaded, ())
-, taskApply = const $ transShell $ do
+, taskApply = transShell $ do
     hasAgent <- isSshAgentExist
     unless hasAgent $ bash_ "eval" ["`ssh-agent`"]
     _ <- bash "ssh-add" $
          maybe [] (\s -> ["-t", pack $ show s]) mseconds
       <> maybe [] (\p -> [toTextArg p]) mkey
     pure ()
-, taskReverse = const $ transShell $ errExit False $ do
+, taskReverse = transShell $ errExit False $ do
     _ <- bash "ssh-add" $
       ["-d"] <> maybe [] (\p -> [toTextArg p]) mkey <> [" > /dev/null 2>&1"]
     pure ()
@@ -154,12 +154,12 @@ sudoFrom user (prog, args) = ("sudo", ["-i", "-u " <> user] ++ toTextArg prog : 
 aptPackages :: RemoteHost -> [Text] -> Task ()
 aptPackages rh pkgs = AtomTask {
   taskName = Just $ "Installation of " <> T.intercalate ", " pkgs <> " via apt-get"
-, taskCheck = const $ transShell $ errExit False $ do
+, taskCheck = transShell $ errExit False $ do
     reses <- traverse isNotInstalled pkgs
     pure (or reses, ())
-, taskApply = const $ void $ transShell $
+, taskApply = void $ transShell $
     shellRemoteSSH rh [sudo ("apt-get", ["update"]), sudo ("apt-get", "install":"-y":pkgs)]
-, taskReverse = const $ transShell $ errExit False $ do
+, taskReverse = transShell $ errExit False $ do
     _ <- shellRemoteSSH rh [sudo ("apt-get", "remove":"-y":pkgs)]
     pure ()
 }
@@ -173,27 +173,27 @@ aptPackages rh pkgs = AtomTask {
 ensureRemoteFolder :: RemoteHost -> Text -> Text -> Task ()
 ensureRemoteFolder rh folder user = AtomTask {
   taskName = Just $ "Ensure folder " <> folder <> " at " <> remoteAddress rh
-, taskCheck = const $ transShell $ errExit False $ do
+, taskCheck = transShell $ errExit False $ do
     _ <- shellRemoteSSH rh [sudo ("ls", [folder <> " > /dev/null 2>&1"])] -- TODO: check that is directory and own user
     err <- lastExitCode
     pure (err /= 0, ())
-, taskApply = const $ void $ transShell $ shellRemoteSSH rh [
+, taskApply = void $ transShell $ shellRemoteSSH rh [
     sudo ("mkdir", ["-p", folder])
   , sudo ("chown", ["-R", user, folder])]
-, taskReverse = const $ pure ()
+, taskReverse = pure ()
 }
 
 -- | Add user on remote host
 addUser :: RemoteHost -> Text -> Task ()
 addUser rh user = AtomTask {
   taskName = Just $ "Creation of user " <> user
-, taskCheck = const $ transShell $ errExit False $ do
+, taskCheck = transShell $ errExit False $ do
     _ <- shellRemoteSSH rh [sudo ("id", ["-u", user <> " > /dev/null 2>&1"])]
     err <- lastExitCode
     pure (err /= 0, ())
-, taskApply = const $ void $ transShell $
+, taskApply = void $ transShell $
     shellRemoteSSH rh [sudo ("useradd", ["-m", "-s /bin/bash", user])]
-, taskReverse = const $ transShell $ errExit False $ do
+, taskReverse = transShell $ errExit False $ do
     _ <- shellRemoteSSH rh [sudo ("userdel", ["-r", user])]
     pure ()
 }
@@ -202,17 +202,17 @@ addUser rh user = AtomTask {
 installNix :: RemoteHost -> Text -> Task ()
 installNix rh deployUser = AtomTask {
   taskName = Just "Installation of nix package manager"
-, taskCheck = const $ transShell $ errExit False $ do
+, taskCheck = transShell $ errExit False $ do
     _ <- shellRemoteSSH rh [raiseNixEnv deployUser, ("which", ["nix-build > /dev/null 2>&1"])]
     err <- lastExitCode
     pure (err /= 0, ())
-, taskApply = const $ void $ transShell $
+, taskApply = void $ transShell $
     shellRemoteSSH rh [
         sudo ("mkdir", ["-m 0755", "/nix"])
       , sudo ("chown", [deployUser, "-R", "/nix"])
       , sudoFrom deployUser ("curl", ["https://nixos.org/nix/install", "-o /tmp/install_nix.sh"])
       , sudoFrom deployUser ("sh", ["/tmp/install_nix.sh"])]
-, taskReverse = const $ transShell $ errExit False $ do
+, taskReverse = transShell $ errExit False $ do
     _ <- shellRemoteSSH rh [
         sudo ("rm", ["-rf", "/nix"])
       , sudoFrom deployUser ("rm", ["-rf", "~/.nix-*"])]
@@ -224,12 +224,12 @@ installNix rh deployUser = AtomTask {
 makeNixLinks :: RemoteHost -> Text -> Task ()
 makeNixLinks rh deployUser = AtomTask {
   taskName = Just $ "Making global nix symlinks from user " <> deployUser
-, taskCheck = const $ transShell $ errExit False $ do
+, taskCheck = transShell $ errExit False $ do
     isStore <- checkFile "/usr/bin/nix-store"
     pure (not isStore, ())
-, taskApply = const $ void $ transShell $
+, taskApply = void $ transShell $
     shellRemoteSSH rh [sudo ("ln", ["-s", "/home/" <> deployUser <> "/.nix-profile/bin/nix-store", "/usr/bin/nix-store"])]
-, taskReverse = const $ transShell $ errExit False $ do
+, taskReverse = transShell $ errExit False $ do
     _ <- shellRemoteSSH rh [sudo ("rm", ["-f", "/usr/bin/nix-store"])]
     pure ()
 }
@@ -248,15 +248,15 @@ raiseNixEnv deployUser = ("source", ["/home/" <> deployUser <> "/.nix-profile/et
 genNixSignKeys :: Task ()
 genNixSignKeys = AtomTask {
   taskName = Just "Generate local signin keys for closures"
-, taskCheck = const $ transShell $ errExit False $ do
+, taskCheck = transShell $ errExit False $ do
     privateExist <- test_f "/etc/nix/signing-key.sec"
     publicExist <- test_f "/etc/nix/signing-key.pub"
     pure (not privateExist || not publicExist, ())
-, taskApply = const $ transShell $ escaping False $ do
+, taskApply = transShell $ escaping False $ do
     bash_ "sudo mkdir -p /etc/nix || true" []
     bash_ "(umask 277 && sudo openssl genrsa -out /etc/nix/signing-key.sec 2048 && sudo chown $(whoami) /etc/nix/signing-key.sec)" []
     bash_ "sudo openssl rsa -in /etc/nix/signing-key.sec -pubout -out /etc/nix/signing-key.pub" []
-, taskReverse = const $ transShell $ errExit False $
+, taskReverse = transShell $ errExit False $
     bash_ "sudo" ["rm", "-f", "/etc/nix/signing-key.sec", "/etc/nix/signing-key.pub"]
 }
 
@@ -264,17 +264,17 @@ genNixSignKeys = AtomTask {
 copyNixSignKeys :: RemoteHost -> Task ()
 copyNixSignKeys rh = AtomTask {
   taskName = Just $ "Copy signing keys to " <> remoteAddress rh
-, taskCheck = const $ transShell $ errExit False $ do
+, taskCheck = transShell $ errExit False $ do
     _ <- shellRemoteSSH rh [sudo ("ls", [keyPos <> " > /dev/null 2>&1"])]
     err <- lastExitCode
     pure (err /= 0, ())
-, taskApply = const $ transShell $ do
+, taskApply = transShell $ do
     _ <- errExit False $ shellRemoteSSH rh [sudo ("mkdir", ["-p", "/etc/nix"])]
     let tmpKeyPos = "~/signing-key.pub"
     remoteScpTo rh (fromText keyPos) (fromText tmpKeyPos)
     _ <- shellRemoteSSH rh [sudo ("mv", [tmpKeyPos, keyPos])]
     pure ()
-, taskReverse = const $ transShell $ errExit False $ do
+, taskReverse = transShell $ errExit False $ do
     _ <- shellRemoteSSH rh [sudo ("rm", ["-f", keyPos])]
     pure ()
 }
@@ -285,12 +285,12 @@ copyNixSignKeys rh = AtomTask {
 nixBuild :: NixBuildInfo -> Task [FilePath]
 nixBuild NixBuildInfo{..} = AtomTask {
   taskName = Just $ "Local nix-build of " <> toTextIgnore nixBuildFile
-, taskCheck = const $ pure (True, [])
-, taskApply = const $ transShell $ do
+, taskCheck = pure (True, [])
+, taskApply = transShell $ do
     nixFileText <- toTextWarn nixBuildFile
     bash_ "nix-build" [maybe "" (("-I ssh-config-file=" <>) . toTextIgnore) nixBuildSshConfig, nixFileText]
     fmap fromText . T.lines <$> bash "nix-env" ["-qa", "--no-name", "--out-path", "-f " <> nixFileText]
-, taskReverse = const $ pure ()
+, taskReverse = pure ()
 }
   where keyPos = "/etc/nix/signing-key.pub"
 
@@ -298,14 +298,14 @@ nixBuild NixBuildInfo{..} = AtomTask {
 copyDeploySshKeys :: RemoteHost -> Text -> Task ()
 copyDeploySshKeys rh deployUser = AtomTask {
   taskName = Just $ "Copy SSH keys for user " <> deployUser
-, taskCheck = const $ pure (True, ())
-, taskApply = const $ transShell $ do
+, taskCheck = pure (True, ())
+, taskApply = transShell $ do
     let home user = if user == "root" then "/root" else "/home/" <> user
     _ <- shellRemoteSSH rh [
         sudo ("cp", ["-r", home (remoteUser rh) <> "/.ssh", home deployUser <> "/.ssh"])
       , sudo ("chown", [deployUser, "-R", home deployUser <> "/.ssh"])]
     pure ()
-, taskReverse = const $ pure ()
+, taskReverse = pure ()
 }
   where
 
@@ -313,15 +313,15 @@ copyDeploySshKeys rh deployUser = AtomTask {
 nixCopyClosures :: RemoteHost -> Maybe Text -> Text -> [FilePath] -> Task ()
 nixCopyClosures rh mkey deployUser closures = AtomTask {
     taskName = Just $ "Copy closures to " <> remoteAddress rh
-  , taskCheck = const $ pure (True, ())
-  , taskApply = const $ transShell $ do
+  , taskCheck = pure (True, ())
+  , taskApply = transShell $ do
       let keyArg = maybe "" (\key -> " -i \"" <> key <> "\"") mkey
       let sshOpts = "NIX_SSHOPTS='-p " <> pack (show $ remotePort rh) <> keyArg <> "'"
       _ <- escaping False $ run_ (fromText sshOpts) $ ["nix-copy-closure", "--sign", "--gzip", "--to", remoteHostTarget rh { remoteUser = deployUser }]  ++ fmap toTextArg closures
       let installProfile closure = sudoFrom deployUser ("nix-env", ["-p /opt/deploy/profile", "-i", toTextArg closure])
       _ <- shellRemoteSSH rh $ raiseNixEnv deployUser : fmap installProfile closures
       pure ()
-  , taskReverse = const $ transShell $ errExit False $ do
+  , taskReverse = transShell $ errExit False $ do
       let removeProfile closure = sudoFrom deployUser ("nix-env", ["nix-env", "-p /opt/deploy/profile", "-e", toTextArg closure])
       _ <- shellRemoteSSH rh (raiseNixEnv deployUser : fmap removeProfile closures)
       pure ()
@@ -331,11 +331,11 @@ nixCopyClosures rh mkey deployUser closures = AtomTask {
 nixCreateProfile :: RemoteHost -> Text -> Task ()
 nixCreateProfile rh deployUser = AtomTask {
     taskName = Just $ "Create nix profile for " <> deployUser <> " at " <> remoteAddress rh
-  , taskCheck = const $ transShell $ errExit False $ do
+  , taskCheck = transShell $ errExit False $ do
       _ <- shellRemoteSSH rh [sudo ("ls", ["/opt/" <> deployUser <> " > /dev/null 2>&1"])]
       err <- lastExitCode
       pure (err /= 0, ())
-  , taskApply = const $ transShell $ do
+  , taskApply = transShell $ do
       let profileDir = "/opt/" <> deployUser
       _ <- shellRemoteSSH rh [
           sudo ("mkdir", ["-p", profileDir])
@@ -343,7 +343,7 @@ nixCreateProfile rh deployUser = AtomTask {
         , sudo ("ln", ["-s", profileDir <> "/profile", "/nix/var/nix/gcroots/" <> deployUser])
         ]
       pure ()
-  , taskReverse = const $ transShell $ errExit False $ do
+  , taskReverse = transShell $ errExit False $ do
       _ <- shellRemoteSSH rh [sudo ("rm", ["-rf", "/opt/" <> deployUser, "/nix/var/nix/gcroots/" <> deployUser])]
       pure ()
   }
@@ -352,11 +352,11 @@ nixCreateProfile rh deployUser = AtomTask {
 nixExtractDeriv :: NixBuildInfo -> Text -> Task Text
 nixExtractDeriv NixBuildInfo{..} name = AtomTask {
     taskName = Just $ "Get deriviation for " <> name
-  , taskCheck = const $ transShell $ do
+  , taskCheck = transShell $ do
       res <- extract
       pure (False, T.filter (\c -> c /= '\r' && c /= '\n') res)
-  , taskApply = const $ transShell extract
-  , taskReverse = const $ pure ()
+  , taskApply = transShell extract
+  , taskReverse = pure ()
   }
   where
     extract = do
@@ -367,15 +367,15 @@ nixExtractDeriv NixBuildInfo{..} name = AtomTask {
 nixSymlinkService :: RemoteHost -> Text -> Text -> Bool -> Task ()
 nixSymlinkService rh deriv serviceName enable = AtomTask {
     taskName = Just $ "Symlink systemd service " <> serviceName <> " at " <> remoteAddress rh
-  , taskCheck = const $ pure (True, ())
-  , taskApply = const $ transShell $ do
+  , taskCheck = pure (True, ())
+  , taskApply = transShell $ do
       _ <- errExit False $ shellRemoteSSH rh [sudo ("rm", ["-f", servicePath])]
       _ <- shellRemoteSSH rh $
         [ sudo ("cp", [deriv, servicePath])]
         ++ if enable then [sudo ("systemctl", ["enable", serviceName <> ".service"])] else []
         ++ [sudo ("systemctl", ["daemon-reload"])]
       pure ()
-  , taskReverse = const $ transShell $ errExit False $ do
+  , taskReverse = transShell $ errExit False $ do
       _ <- shellRemoteSSH rh $
            if enable then [sudo ("systemctl", ["disable", serviceName <> ".service"])] else []
         ++ [sudo ("rm", ["-f", servicePath])]
@@ -388,27 +388,27 @@ nixSymlinkService rh deriv serviceName enable = AtomTask {
 restartRemoteService :: RemoteHost -> Text -> Task ()
 restartRemoteService rh serviceName = AtomTask {
     taskName = Just $ "Restart systemd service " <> serviceName <> " at " <> remoteAddress rh
-  , taskCheck = const $ pure (True, ())
-  , taskApply = const $ transShell $ do
+  , taskCheck = pure (True, ())
+  , taskApply = transShell $ do
       _ <- shellRemoteSSH rh [sudo ("systemctl", ["restart", serviceName])]
       pure ()
-  , taskReverse = const $ pure ()
+  , taskReverse = pure ()
   }
 
 -- | Ensure that postgres is installed and init it with the given script (derivation path)
 installPostgres :: RemoteHost -> Text -> Task ()
 installPostgres rh derivSql =  AtomTask {
   taskName = Just $ "Init postgresql at " <> remoteAddress rh
-, taskCheck = const $ transShell $ errExit False $ do
+, taskCheck = transShell $ errExit False $ do
     reses <- isNotInstalled "postgresql"
     pure (reses, ())
-, taskApply = const $ void $ transShell $
+, taskApply = void $ transShell $
     shellRemoteSSH rh [
         sudo ("apt-get", ["install", "-y", "postgresql", "postgresql-contrib"])
       , sudo ("systemctl", ["enable", "postgresql"])
       , sudo ("systemctl", ["start", "postgresql"])
       , sudoFrom "postgres" ("psql", ["-f " <> derivSql])]
-, taskReverse = const $ transShell $ errExit False $ do
+, taskReverse = transShell $ errExit False $ do
     _ <- shellRemoteSSH rh [sudo ("apt-get", ["remove", "-y", "postgresql"])]
     pure ()
 }


### PR DESCRIPTION
Implements #5 and #12 

* Используется nix выражение для задания всех настроек и derivations.
* Можно деплоить на несколько машин одним конфигом.
* Прописывается `/etc/hosts` на подобие `nixops`
* Улучшения в логах, пишет имя машины и не пишет лишних проверок, которые проходят всегда.

Проверка:
1. Поднять пример из `examples/single`
2. Поднять пример из `examples/multiple`